### PR TITLE
Add depth-recorder service

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,6 +20,25 @@
         "type": "github"
       }
     },
+    "depth-recorder": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1697648799,
+        "narHash": "sha256-mxdm8vNEwNlolWIjsX60KbljKADh/mKRMq8+SV7+dPs=",
+        "owner": "nordic-dev-net",
+        "repo": "depth-recorder",
+        "rev": "fabc9ce161b72d8149f3dfc31c6d996ffa972bf5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nordic-dev-net",
+        "repo": "depth-recorder",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -59,6 +78,24 @@
         "systems": "systems_2"
       },
       "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "inputs": {
+        "systems": "systems_3"
+      },
+      "locked": {
         "lastModified": 1692799911,
         "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
         "owner": "numtide",
@@ -74,15 +111,15 @@
     },
     "hydrophonitor-gps": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_2"
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1694371631,
-        "narHash": "sha256-o2lx75F0VnFnBKajbVbEUuQRcbcSHdCxjUVjdaAoAn8=",
+        "lastModified": 1694708111,
+        "narHash": "sha256-295lPh/11s4hHJsZyF2cXGCPNw1y0dXwq6s0yX9ZtAY=",
         "owner": "nordic-dev-net",
         "repo": "hydrophonitor-gps",
-        "rev": "d13bb78ce2d16b842f0be802f9d669ba32a35c3d",
+        "rev": "883e15d872d7bb763bbe89862747e26f6b32460e",
         "type": "github"
       },
       "original": {
@@ -125,6 +162,38 @@
     },
     "nixpkgs_2": {
       "locked": {
+        "lastModified": 1696879762,
+        "narHash": "sha256-Ud6bH4DMcYHUDKavNMxAhcIpDGgHMyL/yaDEAVSImQY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f99e5f03cc0aa231ab5950a15ed02afec45ed51a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1694183432,
+        "narHash": "sha256-YyPGNapgZNNj51ylQMw9lAgvxtM2ai1HZVUu3GS8Fng=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f99e5f03cc0aa231ab5950a15ed02afec45ed51a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
         "lastModified": 1694183432,
         "narHash": "sha256-YyPGNapgZNNj51ylQMw9lAgvxtM2ai1HZVUu3GS8Fng=",
         "owner": "NixOS",
@@ -139,29 +208,14 @@
         "type": "github"
       }
     },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1694422566,
-        "narHash": "sha256-lHJ+A9esOz9vln/3CJG23FV6Wd2OoOFbDeEs4cMGMqc=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "3a2786eea085f040a66ecde1bc3ddc7099f6dbeb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "deploy-rs": "deploy-rs",
-        "flake-utils": "flake-utils",
+        "depth-recorder": "depth-recorder",
+        "flake-utils": "flake-utils_2",
         "hydrophonitor-gps": "hydrophonitor-gps",
         "nixos-hardware": "nixos-hardware",
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_4"
       }
     },
     "systems": {
@@ -180,6 +234,21 @@
       }
     },
     "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -9,6 +9,7 @@
     flake-utils.url = "github:numtide/flake-utils";
     deploy-rs.url = "github:serokell/deploy-rs";
     hydrophonitor-gps.url = "github:nordic-dev-net/hydrophonitor-gps";
+    depth-recorder.url = "github:nordic-dev-net/depth-recorder";
   };
   outputs = {
     self,
@@ -17,6 +18,7 @@
     flake-utils,
     deploy-rs,
     hydrophonitor-gps,
+    depth-recorder,
     ...
   }: let
     forEachSystem = nixpkgs.lib.genAttrs ["x86_64-linux" "aarch64-linux"];
@@ -44,6 +46,7 @@
           ./modules/shutdown-button/service.nix
           nixos-hardware.nixosModules.raspberry-pi-4
           hydrophonitor-gps.nixosModules.hydrophonitor-gps
+          depth-recorder.nixosModules.depth-recorder
           "${nixpkgs}/nixos/modules/installer/sd-card/sd-image-aarch64.nix"
         ];
       };

--- a/targets/raspberry-pi-3/default.nix
+++ b/targets/raspberry-pi-3/default.nix
@@ -64,7 +64,7 @@ in {
 
   services.gps-recorder = {
     enable = true;
-    output-folder = "/output/gps";
+    output-path = "/output/gps";
     interval-secs = 10;
   };
 

--- a/targets/raspberry-pi-4/default.nix
+++ b/targets/raspberry-pi-4/default.nix
@@ -47,10 +47,15 @@ in {
 
   services.gps-recorder = {
     enable = true;
-    output-folder = "/output/gps";
+    output-path = "/output/gps";
     interval-secs = 10;
   };
 
+  services.depth-recorder = {
+    enable = true;
+    output-path = "/output/depth";
+    interval-secs = 5;
+  };
 
   # disabled for now, with current config
   # RTC resets after shutdown


### PR DESCRIPTION
WIP review for adding the `depth-recorder` service.

Depth-recorder is now added as its own repository, written in Rust: https://github.com/nordic-dev-net/depth-recorder

Initial implementation for testing connects to an analog peripheral (in initial testing, a potentiometer) through the ADS1015 ADC (channel A0) using I2C. ADC is connected to the default I2C pins on Raspberry Pi (GPIO 3 & 5).

Right now, the program does not convert the values read from ADC, but rather writes them directly to a file. A placeholder function for conversion has been added, but nothing is done there yet.

Eventually, a 4-20mA current loop pressure sensor will be connected to the ADC. An appropriate resistor needs to be added to map the 4-20mA current to the ADC's supported voltage range, in our case from 0V to max 3.3V (to my current understanding). ADS1015 has 12-bit precision, so voltage values 0-3.3V should map to range 0-4096. This can then be mapped to the pressure sensor's range to obtain the measured pressure. This should finally be converted to depth.

Next steps:
- the service should be deployed and tested on the Raspberry Pi to verify that recording values to the specified file at specified intervals works correctly
- conversion from the voltage value read from the ADC to pressure to depth should be implemented. 

Closes #22 