### PR TITLE
Set audio-recorder service to start after sound.target reached

### DIFF
--- a/modules/audio-recorder/default.nix
+++ b/modules/audio-recorder/default.nix
@@ -72,7 +72,9 @@
         User = "root"; # Replace with appropriate user
         Restart = "always";
       };
-      startLimitIntervalSec = 0;
+      unitConfig = {
+        After = "sound.target";
+      };
     };
   };
 }

--- a/targets/raspberry-pi-3/default.nix
+++ b/targets/raspberry-pi-3/default.nix
@@ -13,6 +13,7 @@ in {
 
   boot = {
     # disable internal sound card and vc4 gpu
+    # to set USB sound card as default
     blacklistedKernelModules = ["snd_bcm2835" "vc4"];
     # enable i2c and rtc modules
     kernelModules = ["i2c-dev" "i2c_bcm2708" "rtc_ds1307"];

--- a/targets/raspberry-pi-4/default.nix
+++ b/targets/raspberry-pi-4/default.nix
@@ -9,6 +9,7 @@ in {
   sdImage.compressImage = false;
 
   # disable internal sound card and vc4 gpu
+  # to set USB sound card as default
   boot.blacklistedKernelModules = ["snd_bcm2835" "vc4"];
   # enable i2c and rtc modules
   boot.kernelModules = ["i2c-dev" "i2c_bcm2708" "rtc_ds1307"];
@@ -50,8 +51,11 @@ in {
     interval-secs = 10;
   };
 
+
+  # disabled for now, with current config
+  # RTC resets after shutdown
   services.i2c-rtc-start = {
-    enable = true;
+    enable = false;
     i2c-bus = 1;
   };
 


### PR DESCRIPTION
With this setting, audio-recorder service starts after sound card target has been reached. Based on testing, the sound card might not still be recognized at the first attempt, but this significantly reduces the amount of restarts at boot.

Also, disable i2c-rtc-start, which is not functioning correctly currently (RTC resets randomly to 01-01-2000 after shutdown).