### PR TITLE
Add service for exporting journalctl logs & fix startLimitInterval in service configs

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,6 @@
+# Logging setup for hydrophonitor
+
+Everything that is run on hydrophonitor is set up as systemd services. Anything that these services print to standard output or standard error is written to the systemd journal. Therefore, to capture logs from these services as well from other system components, journal from the current boot is exported to `/output/<deployment>/logs` with two systemd services, `journalctl-log-export` and `journalctl-log-export-on-shutdown`. Both a periodically run and on shutdown executed service are defined to ensure that some logs are preserved even if the system is powered off uncleanly and log export on shutdown is not executed.
+
+- `journalctl-log-export.service` is triggered by a systemd timer every five minutes. On first run, the service defines the name for the log file to which logs are periodically exported and exports the journal to the file with journalctl. On subsequent runs, logs are re-exported to the same file.
+- `journalctl-log-export-on-shutdown.service` runs on system shutdown (after audio-recorder service has stopped) and exports the journal to a file that is separate from the periodically updated log file. This should therefore contain logs from the whole boot.

--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1697648799,
-        "narHash": "sha256-mxdm8vNEwNlolWIjsX60KbljKADh/mKRMq8+SV7+dPs=",
+        "lastModified": 1697704925,
+        "narHash": "sha256-m2i5tydxHAgjs9vqn5tm5MNiPnTLNCDEKrwlF6bbvQE=",
         "owner": "nordic-dev-net",
         "repo": "depth-recorder",
-        "rev": "fabc9ce161b72d8149f3dfc31c6d996ffa972bf5",
+        "rev": "78d26ffe6c6f4d1f3bfffc52d366456bac926ed2",
         "type": "github"
       },
       "original": {
@@ -115,11 +115,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1694708111,
-        "narHash": "sha256-295lPh/11s4hHJsZyF2cXGCPNw1y0dXwq6s0yX9ZtAY=",
+        "lastModified": 1697705076,
+        "narHash": "sha256-NlrHgrZGZbRGKZGytfYBzaW9FsU4N5zofwB5qVXSXXM=",
         "owner": "nordic-dev-net",
         "repo": "hydrophonitor-gps",
-        "rev": "883e15d872d7bb763bbe89862747e26f6b32460e",
+        "rev": "062ac75a39a20ede882f651d551f66581e63a3e0",
         "type": "github"
       },
       "original": {
@@ -182,7 +182,7 @@
         "narHash": "sha256-YyPGNapgZNNj51ylQMw9lAgvxtM2ai1HZVUu3GS8Fng=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f99e5f03cc0aa231ab5950a15ed02afec45ed51a",
+        "rev": "db9208ab987cdeeedf78ad9b4cf3c55f5ebd269b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,7 @@
         modules = [
           ./targets/raspberry-pi-4
           ./modules/audio-recorder
+          ./modules/logging
           ./modules/real-time-clock/i2c-rtc.nix
           ./modules/shutdown-button/service.nix
           nixos-hardware.nixosModules.raspberry-pi-4

--- a/modules/audio-recorder/default.nix
+++ b/modules/audio-recorder/default.nix
@@ -75,6 +75,7 @@
       unitConfig = {
         After = "sound.target";
       };
+      startLimitIntervalSec = 0;
     };
   };
 }

--- a/modules/audio-recorder/default.nix
+++ b/modules/audio-recorder/default.nix
@@ -73,7 +73,7 @@
         Restart = "always";
       };
       unitConfig = {
-        After = "sound.target";
+        After = ["multi-user.target"];
       };
       startLimitIntervalSec = 0;
     };

--- a/modules/logging/default.nix
+++ b/modules/logging/default.nix
@@ -1,0 +1,61 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}: {
+  options = with lib; {
+    services.journalctl-log-export = {
+      enable = mkEnableOption "Enable exporting journalctl logs to a file.";
+
+      output-folder = mkOption {
+        type = types.str;
+        default = "/output/logs";
+        description = "The folder to save logs to.";
+      };
+    };
+  };
+
+  config = lib.mkIf config.services.journalctl-log-export.enable {
+    systemd.services.journalctl-log-export-on-shutdown = {
+      description = "Journalctl log export on shutdown service";
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        User = "root";
+        Type = "oneshot";
+        RemainAfterExit = true;
+        ExecStart = "${pkgs.coreutils}/bin/mkdir -p ${config.services.journalctl-log-export.output-folder}";
+        ExecStop = ''${pkgs.bash}/bin/bash -c "echo 'Exporting logs at shutdown' && journalctl --boot 0 > ${config.services.journalctl-log-export.output-folder}/$(date +\"%Y_%m_%d-%H_%M_%S\")_journalctl_on_shutdown.txt"'';
+      };
+    };
+
+    systemd.services.journalctl-log-export = {
+      description = "Journalctl log export service";
+      script = ''
+        #!/usr/bin/env bash
+        set -x
+        ${pkgs.coreutils}/bin/echo "Exporting journalctl logs"
+        ${pkgs.coreutils}/bin/mkdir -p ${config.services.journalctl-log-export.output-folder}
+        # if environment variable for output file name is not set, set it with systemctl set-environment
+        if [ -z "$JOURNALCTL_LOG_EXPORT_OUTPUT_FILE" ]; then
+          JOURNALCTL_LOG_EXPORT_OUTPUT_FILE=$(${pkgs.coreutils}/bin/date +"%Y_%m_%d-%H_%M_%S")_journalctl.txt
+          ${pkgs.systemd}/bin/systemctl set-environment JOURNALCTL_LOG_EXPORT_OUTPUT_FILE=$JOURNALCTL_LOG_EXPORT_OUTPUT_FILE
+        fi
+        ${pkgs.systemd}/bin/journalctl --boot 0 > ${config.services.journalctl-log-export.output-folder}/$JOURNALCTL_LOG_EXPORT_OUTPUT_FILE
+      '';
+      serviceConfig = {
+        User = "root";
+        Type = "oneshot";
+      };
+    };
+
+    systemd.timers.journalctl-log-export = {
+    wantedBy = [ "timers.target" ];
+    partOf = [ "journalctl-log-export.service" ];
+    timerConfig = {
+        OnCalendar = "*:0/5"; # every five minutes
+        Unit = "journalctl-log-export.service";
+    };
+};
+  };
+}

--- a/modules/logging/default.nix
+++ b/modules/logging/default.nix
@@ -24,8 +24,10 @@
         User = "root";
         Type = "oneshot";
         RemainAfterExit = true;
-        ExecStart = "${pkgs.coreutils}/bin/mkdir -p ${config.services.journalctl-log-export.output-folder}";
-        ExecStop = ''${pkgs.bash}/bin/bash -c "echo 'Exporting logs at shutdown' && journalctl --boot 0 > ${config.services.journalctl-log-export.output-folder}/$(date +\"%Y_%m_%d-%H_%M_%S\")_journalctl_on_shutdown.txt"'';
+        ExecStop = ''${pkgs.bash}/bin/bash -c "echo \"Exporting logs at shutdown" && journalctl --boot 0 > ${config.services.journalctl-log-export.output-folder}/journalctl_on_shutdown.txt"'';
+      };
+      unitConfig = {
+        Before = ["audio-recorder.service"];
       };
     };
 

--- a/targets/raspberry-pi-4/default.nix
+++ b/targets/raspberry-pi-4/default.nix
@@ -45,6 +45,11 @@ in {
     max-file-time-secs = 60;
   };
 
+  services.journalctl-log-export = {
+    enable = true;
+    output-folder = "/output/logs";
+  };
+
   services.gps-recorder = {
     enable = true;
     output-path = "/output/gps";


### PR DESCRIPTION
This PR adds a logging service that exports journalctl logs to a file in `/output/logs` every five minutes. Upon first export, the log file name is defined as an environment variable and exported with `systemctl set-environment`, so that subsequent exports can overwrite the existing log file.

The service also contains another oneshot service to export logs to another file upon system shutdown. This is achieved by giving the export service a `Before = ["audio-recorder.service"];` unitConfig. Systemd applies the start order in reverse on shutting down, hence this ensures that this service starts before `audio-recorder.service` and exits only after `audio-recorder.service` has stopped. On exit, the command defined in `ExecStop` is executed.

What I could not get working with the shutdown log export was to include a timestamp in the file where logs are written. When I tried it with this ExecStop:
```
ExecStop = ''${pkgs.bash}/bin/bash -c "FILE=$(${pkgs.coreutils}/bin/date +"%Y_%m_%d-%H_%M_%S")_journalctl_on_shutdown.txt; echo \"Exporting logs at shutdown to $FILE\" && journalctl --boot 0 > ${config.services.journalctl-log-export.output-folder}/$FILE"'';
```

This is what showed up on journalctl:
```
Jan 15 18:09:28 nixos bash[1876]: Exporting logs at shutdown to /nix/store/2hvfch152hp91kf4rm8giiflg0ndqll9-unit-journalctl-log-export-on-shutdown.service_874c6b8984b84df7b3d6b2bead37ac03_/run/credentials/journalctl-log-export-on-shutdown.service-nixos__/var/lib_journalctl_on_shutdown.txt
Jan 15 18:09:28 nixos bash[1880]: /nix/store/xv90a9497jmi4v1hx1y007al4vrk555c-bash-5.2-p15/bin/bash: line 1: /output/logs//nix/store/2hvfch152hp91kf4rm8giiflg0ndqll9-unit-journalctl-log-export-on-shutdown.service_874c6b8984b84df7b3d6b2bead37ac03_/run/credentials/journalctl-log-export-on-shutdown.service-nixos__/var/lib_journalctl_on_shutdown.txt: No such file or directory
```

Hence, log file on shutdown is named simply journalctrl_on_shutdown.txt. This should not be an issue as the next upcoming change will place all output files to deployment-specific directories. 

In addition, this PR contains two fixes for service configs:
- fix for audio-recorder unitConfig `After` configuration. For some reason, `sound.target` does not appear to work as a target for the service so that it would only be started after `sound.target` is reached. However, `multi-user.target` does work.
- restoring `startLimitIntervalSec = 0;` in all services (with hydrophonitor-gps and depth-recorder versions updated in flake.lock