### PR TITLE
Create deployment-specific directories to write files to

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -8,5 +8,4 @@ TARGET_USER="kaskelotti"
 DEFAULT_IP="192.168.1.112"
 TARGET_IP=${1:-${DEFAULT_IP}}
 
-
-(export NIX_SSHOPTS="-tt"; nixos-rebuild switch --flake .#raspberry-pi-4 --target-host ${TARGET_USER}@${TARGET_IP} --use-remote-sudo)
+NIX_SSHOPTS="-o RequestTTY=force" nixos-rebuild switch --flake .#raspberry-pi-4 --target-host ${TARGET_USER}@${TARGET_IP} --use-remote-sudo

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -x
+
+TARGET_USER="kaskelotti"
+
+# Target IP can be passed as command line argument
+DEFAULT_IP="192.168.1.112"
+TARGET_IP=${1:-${DEFAULT_IP}}
+
+
+(export NIX_SSHOPTS="-tt"; nixos-rebuild switch --flake .#raspberry-pi-4 --target-host ${TARGET_USER}@${TARGET_IP} --use-remote-sudo)

--- a/flake.lock
+++ b/flake.lock
@@ -35,7 +35,6 @@
       },
       "original": {
         "owner": "nordic-dev-net",
-        "ref": "4-update-depth-recorder-service-for-deployment-specific-output-directories",
         "repo": "depth-recorder",
         "type": "github"
       }
@@ -125,7 +124,6 @@
       },
       "original": {
         "owner": "nordic-dev-net",
-        "ref": "4-update-gps-recorder-service-for-deployment-specific-output-directories",
         "repo": "hydrophonitor-gps",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1705601300,
+        "lastModified": 1708773379,
         "narHash": "sha256-kNFLbrmw5l5NOO1cQ+yLHQ5rVKYhcDtHqvN3EWgDQAk=",
         "owner": "nordic-dev-net",
         "repo": "depth-recorder",
-        "rev": "44bc429ca446564562862b4b5ef41cbdab0ae0e0",
+        "rev": "336a6794205426bf6529eb429770c075836e1b50",
         "type": "github"
       },
       "original": {
@@ -116,11 +116,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1705601254,
+        "lastModified": 1708773345,
         "narHash": "sha256-/7euqzrdJnyLa69jnPHp96N10LFINZcJkzeOOpedwco=",
         "owner": "nordic-dev-net",
         "repo": "hydrophonitor-gps",
-        "rev": "70de661c0ec43ce95138c09962506f4459a20fc5",
+        "rev": "4b983412a8dadb8e88b01e63e6aaedba813de6e3",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1694513707,
-        "narHash": "sha256-wE5kHco3+FQjc+MwTPwLVqYz4hM7uno2CgXDXUFMCpc=",
+        "lastModified": 1704875591,
+        "narHash": "sha256-eWRLbqRcrILgztU/m/k7CYLzETKNbv0OsT2GjkaNm8A=",
         "owner": "serokell",
         "repo": "deploy-rs",
-        "rev": "31c32fb2959103a796e07bbe47e0a5e287c343a8",
+        "rev": "1776009f1f3fb2b5d236b84d9815f2edee463a9b",
         "type": "github"
       },
       "original": {
@@ -26,15 +26,16 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1697704925,
-        "narHash": "sha256-m2i5tydxHAgjs9vqn5tm5MNiPnTLNCDEKrwlF6bbvQE=",
+        "lastModified": 1705601300,
+        "narHash": "sha256-kNFLbrmw5l5NOO1cQ+yLHQ5rVKYhcDtHqvN3EWgDQAk=",
         "owner": "nordic-dev-net",
         "repo": "depth-recorder",
-        "rev": "78d26ffe6c6f4d1f3bfffc52d366456bac926ed2",
+        "rev": "44bc429ca446564562862b4b5ef41cbdab0ae0e0",
         "type": "github"
       },
       "original": {
         "owner": "nordic-dev-net",
+        "ref": "4-update-depth-recorder-service-for-deployment-specific-output-directories",
         "repo": "depth-recorder",
         "type": "github"
       }
@@ -42,11 +43,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1668681692,
-        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
         "type": "github"
       },
       "original": {
@@ -56,24 +57,6 @@
       }
     },
     "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
       "inputs": {
         "systems": "systems_2"
       },
@@ -91,9 +74,27 @@
         "type": "github"
       }
     },
-    "flake-utils_3": {
+    "flake-utils_2": {
       "inputs": {
         "systems": "systems_3"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "inputs": {
+        "systems": "systems_4"
       },
       "locked": {
         "lastModified": 1692799911,
@@ -115,26 +116,27 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1697705076,
-        "narHash": "sha256-NlrHgrZGZbRGKZGytfYBzaW9FsU4N5zofwB5qVXSXXM=",
+        "lastModified": 1705601254,
+        "narHash": "sha256-/7euqzrdJnyLa69jnPHp96N10LFINZcJkzeOOpedwco=",
         "owner": "nordic-dev-net",
         "repo": "hydrophonitor-gps",
-        "rev": "062ac75a39a20ede882f651d551f66581e63a3e0",
+        "rev": "70de661c0ec43ce95138c09962506f4459a20fc5",
         "type": "github"
       },
       "original": {
         "owner": "nordic-dev-net",
+        "ref": "4-update-gps-recorder-service-for-deployment-specific-output-directories",
         "repo": "hydrophonitor-gps",
         "type": "github"
       }
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1694591211,
-        "narHash": "sha256-NPP7XGZH+Q5ey7nE2zGLrBrzKmLYPhj8YgsTSdhH0D4=",
+        "lastModified": 1705312285,
+        "narHash": "sha256-rd+dY+v61Y8w3u9bukO/hB55Xl4wXv4/yC8rCGVnK5U=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "3ccd87fcdae4732fe33773cefa4375c641a057e7",
+        "rev": "bee2202bec57e521e3bd8acd526884b9767d7fa0",
         "type": "github"
       },
       "original": {
@@ -146,11 +148,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1671417167,
-        "narHash": "sha256-JkHam6WQOwZN1t2C2sbp1TqMv3TVRjzrdoejqfefwrM=",
+        "lastModified": 1702272962,
+        "narHash": "sha256-D+zHwkwPc6oYQ4G3A1HuadopqRwUY/JkMwHz1YF7j4Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bb31220cca6d044baa6dc2715b07497a2a7c4bc7",
+        "rev": "e97b3e4186bcadf0ef1b6be22b8558eab1cdeb5d",
         "type": "github"
       },
       "original": {
@@ -194,11 +196,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1694183432,
-        "narHash": "sha256-YyPGNapgZNNj51ylQMw9lAgvxtM2ai1HZVUu3GS8Fng=",
+        "lastModified": 1705496572,
+        "narHash": "sha256-rPIe9G5EBLXdBdn9ilGc0nq082lzQd0xGGe092R/5QE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "db9208ab987cdeeedf78ad9b4cf3c55f5ebd269b",
+        "rev": "842d9d80cfd4560648c785f8a4e6f3b096790e19",
         "type": "github"
       },
       "original": {
@@ -263,13 +265,31 @@
         "type": "github"
       }
     },
-    "utils": {
+    "systems_4": {
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -8,8 +8,8 @@
     nixos-hardware.url = "github:NixOS/nixos-hardware/master";
     flake-utils.url = "github:numtide/flake-utils";
     deploy-rs.url = "github:serokell/deploy-rs";
-    hydrophonitor-gps.url = "github:nordic-dev-net/hydrophonitor-gps/4-update-gps-recorder-service-for-deployment-specific-output-directories";
-    depth-recorder.url = "github:nordic-dev-net/depth-recorder/4-update-depth-recorder-service-for-deployment-specific-output-directories";
+    hydrophonitor-gps.url = "github:nordic-dev-net/hydrophonitor-gps";
+    depth-recorder.url = "github:nordic-dev-net/depth-recorder";
   };
   outputs = {
     self,

--- a/flake.nix
+++ b/flake.nix
@@ -8,8 +8,8 @@
     nixos-hardware.url = "github:NixOS/nixos-hardware/master";
     flake-utils.url = "github:numtide/flake-utils";
     deploy-rs.url = "github:serokell/deploy-rs";
-    hydrophonitor-gps.url = "github:nordic-dev-net/hydrophonitor-gps";
-    depth-recorder.url = "github:nordic-dev-net/depth-recorder";
+    hydrophonitor-gps.url = "github:nordic-dev-net/hydrophonitor-gps/4-update-gps-recorder-service-for-deployment-specific-output-directories";
+    depth-recorder.url = "github:nordic-dev-net/depth-recorder/4-update-depth-recorder-service-for-deployment-specific-output-directories";
   };
   outputs = {
     self,

--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,7 @@
         specialArgs = {inherit pkgs;};
         modules = [
           ./targets/raspberry-pi-4
+          ./modules/deployment-start
           ./modules/audio-recorder
           ./modules/logging
           ./modules/real-time-clock/i2c-rtc.nix

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
       ];
     };
   in {
-    systems = {
+    nixosConfigurations = {
       raspberry-pi-4 = nixpkgs.lib.nixosSystem {
         system = "aarch64-linux";
         specialArgs = {inherit pkgs;};
@@ -75,7 +75,7 @@
           magicRollback = false;
           path =
             deploy-rs.lib.aarch64-linux.activate.nixos
-            self.systems.raspberry-pi-4;
+            self.nixosConfigurations.raspberry-pi-4;
           user = "root";
         };
       };
@@ -88,7 +88,7 @@
           magicRollback = false;
           path =
             deploy-rs.lib.aarch64-linux.activate.nixos
-            self.systems.raspberry-pi-3;
+            self.nixosConfigurations.raspberry-pi-3;
           user = "root";
         };
       };

--- a/modules/audio-recorder/default.nix
+++ b/modules/audio-recorder/default.nix
@@ -55,6 +55,7 @@
       script = ''
         #!/usr/bin/env bash
         set -x
+        # DEPLOYMENT_DIRECTORY is set by the deployment-start service
         OUTPUT_PATH=$DEPLOYMENT_DIRECTORY/${config.services.audio-recorder.output-folder}
         ${pkgs.coreutils}/bin/mkdir -p $OUTPUT_PATH
         ${pkgs.alsaUtils}/bin/arecord -l
@@ -74,7 +75,7 @@
         Restart = "always";
       };
       unitConfig = {
-        After = ["multi-user.target"];
+        After = ["multi-user.target" "deployment-start.service"];
       };
       startLimitIntervalSec = 0;
     };

--- a/modules/audio-recorder/default.nix
+++ b/modules/audio-recorder/default.nix
@@ -10,8 +10,8 @@
 
       output-folder = mkOption {
         type = types.str;
-        default = "/output/audio";
-        description = "The folder to save recordings to.";
+        default = "audio";
+        description = "The folder to save recordings to within the deployment folder.";
       };
 
       sample-rate = mkOption {
@@ -55,7 +55,8 @@
       script = ''
         #!/usr/bin/env bash
         set -x
-        ${pkgs.coreutils}/bin/mkdir -p ${config.services.audio-recorder.output-folder}
+        OUTPUT_PATH=$DEPLOYMENT_DIRECTORY/${config.services.audio-recorder.output-folder}
+        ${pkgs.coreutils}/bin/mkdir -p $OUTPUT_PATH
         ${pkgs.alsaUtils}/bin/arecord -l
         CARD_ID=$(${pkgs.alsaUtils}/bin/arecord -l | grep "USB Audio" | grep -oP '(?<=card )\d')
         DEVICE_ID=$(${pkgs.alsaUtils}/bin/arecord -l | grep "USB Audio" | grep -oP '(?<=device )\d')
@@ -66,7 +67,7 @@
             --rate ${toString config.services.audio-recorder.sample-rate} \
             --channels ${toString config.services.audio-recorder.channels} \
             --use-strftime \
-            ${config.services.audio-recorder.output-folder}/%Y-%m-%d_%H-%M-%S.wav
+            $OUTPUT_PATH/%Y-%m-%dT%H_%M_%S%z.wav
       '';
       serviceConfig = {
         User = "root"; # Replace with appropriate user

--- a/modules/deployment-start/default.nix
+++ b/modules/deployment-start/default.nix
@@ -11,7 +11,7 @@
       output-folder = mkOption {
         type = types.str;
         default = "/output";
-        description = "The folder where deployment directory will be created.";
+        description = "Absolute path to folder where deployment directory will be created.";
       };
     };
   };

--- a/modules/deployment-start/default.nix
+++ b/modules/deployment-start/default.nix
@@ -1,0 +1,39 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}: {
+  options = with lib; {
+    services.deployment-start = {
+      enable = mkEnableOption "Create deployment directory and export path as environment variable for services to write their output data to.";
+
+      output-folder = mkOption {
+        type = types.str;
+        default = "/output";
+        description = "The folder where deployment directory will be created.";
+      };
+    };
+  };
+
+  config = lib.mkIf config.services.deployment-start.enable {
+    systemd.services.deployment-start = {
+      description = "Deployment directory creation service";
+      wantedBy = ["multi-user.target"];
+      script = ''
+        #!/usr/bin/env bash
+        set -x
+        DEPLOYMENT_DIRECTORY=${config.services.deployment-start.output-folder}/$(${pkgs.coreutils}/bin/date +"%Y-%m-%dT%H_%M_%S%z")
+        ${pkgs.systemd}/bin/systemctl set-environment DEPLOYMENT_DIRECTORY=$DEPLOYMENT_DIRECTORY
+        ${pkgs.coreutils}/bin/mkdir -p $DEPLOYMENT_DIRECTORY
+      '';
+      serviceConfig = {
+        User = "root";
+        Type = "oneshot";
+      };
+      unitConfig = {
+        Before = ["audio-recorder.service"];
+      };
+    };
+  };
+}

--- a/modules/deployment-start/default.nix
+++ b/modules/deployment-start/default.nix
@@ -8,7 +8,7 @@
     services.deployment-start = {
       enable = mkEnableOption "Create deployment directory and export path as environment variable for services to write their output data to.";
 
-      output-folder = mkOption {
+      output-path = mkOption {
         type = types.str;
         default = "/output";
         description = "Absolute path to folder where deployment directory will be created.";
@@ -23,7 +23,7 @@
       script = ''
         #!/usr/bin/env bash
         set -x
-        DEPLOYMENT_DIRECTORY=${config.services.deployment-start.output-folder}/$(${pkgs.coreutils}/bin/date +"%Y-%m-%dT%H_%M_%S%z")
+        DEPLOYMENT_DIRECTORY=${config.services.deployment-start.output-path}/$(${pkgs.coreutils}/bin/date +"%Y-%m-%dT%H_%M_%S%z")
         ${pkgs.systemd}/bin/systemctl set-environment DEPLOYMENT_DIRECTORY=$DEPLOYMENT_DIRECTORY
         ${pkgs.coreutils}/bin/mkdir -p $DEPLOYMENT_DIRECTORY
       '';

--- a/modules/logging/default.nix
+++ b/modules/logging/default.nix
@@ -10,8 +10,8 @@
 
       output-folder = mkOption {
         type = types.str;
-        default = "/output/logs";
-        description = "The folder to save logs to.";
+        default = "logs";
+        description = "The folder to save logs to within the deployment folder.";
       };
     };
   };
@@ -19,12 +19,12 @@
   config = lib.mkIf config.services.journalctl-log-export.enable {
     systemd.services.journalctl-log-export-on-shutdown = {
       description = "Journalctl log export on shutdown service";
-      wantedBy = [ "multi-user.target" ];
+      wantedBy = ["multi-user.target"];
       serviceConfig = {
         User = "root";
         Type = "oneshot";
         RemainAfterExit = true;
-        ExecStop = ''${pkgs.bash}/bin/bash -c "echo \"Exporting logs at shutdown" && journalctl --boot 0 > ${config.services.journalctl-log-export.output-folder}/journalctl_on_shutdown.txt"'';
+        ExecStop = ''${pkgs.bash}/bin/bash -c "echo \"Exporting logs at shutdown\" && journalctl --boot 0 > $DEPLOYMENT_DIRECTORY/${config.services.journalctl-log-export.output-folder}/journalctl_on_shutdown.txt"'';
       };
       unitConfig = {
         Before = ["audio-recorder.service"];
@@ -37,13 +37,14 @@
         #!/usr/bin/env bash
         set -x
         ${pkgs.coreutils}/bin/echo "Exporting journalctl logs"
-        ${pkgs.coreutils}/bin/mkdir -p ${config.services.journalctl-log-export.output-folder}
+        OUTPUT_PATH=$DEPLOYMENT_DIRECTORY/${config.services.journalctl-log-export.output-folder}
+        ${pkgs.coreutils}/bin/mkdir -p $OUTPUT_PATH
         # if environment variable for output file name is not set, set it with systemctl set-environment
         if [ -z "$JOURNALCTL_LOG_EXPORT_OUTPUT_FILE" ]; then
-          JOURNALCTL_LOG_EXPORT_OUTPUT_FILE=$(${pkgs.coreutils}/bin/date +"%Y_%m_%d-%H_%M_%S")_journalctl.txt
+          JOURNALCTL_LOG_EXPORT_OUTPUT_FILE=$(${pkgs.coreutils}/bin/date +"%Y-%m-%dT%H_%M_%S%z")_journalctl.txt
           ${pkgs.systemd}/bin/systemctl set-environment JOURNALCTL_LOG_EXPORT_OUTPUT_FILE=$JOURNALCTL_LOG_EXPORT_OUTPUT_FILE
         fi
-        ${pkgs.systemd}/bin/journalctl --boot 0 > ${config.services.journalctl-log-export.output-folder}/$JOURNALCTL_LOG_EXPORT_OUTPUT_FILE
+        ${pkgs.systemd}/bin/journalctl --boot 0 > $OUTPUT_PATH/$JOURNALCTL_LOG_EXPORT_OUTPUT_FILE
       '';
       serviceConfig = {
         User = "root";
@@ -52,12 +53,12 @@
     };
 
     systemd.timers.journalctl-log-export = {
-    wantedBy = [ "timers.target" ];
-    partOf = [ "journalctl-log-export.service" ];
-    timerConfig = {
+      wantedBy = ["timers.target"];
+      partOf = ["journalctl-log-export.service"];
+      timerConfig = {
         OnCalendar = "*:0/5"; # every five minutes
         Unit = "journalctl-log-export.service";
+      };
     };
-};
   };
 }

--- a/modules/logging/default.nix
+++ b/modules/logging/default.nix
@@ -59,6 +59,9 @@
         OnCalendar = "*:0/5"; # every five minutes
         Unit = "journalctl-log-export.service";
       };
+      unitConfig = {
+        After = ["multi-user.target" "deployment-start.service"];
+      };
     };
   };
 }

--- a/targets/raspberry-pi-3/default.nix
+++ b/targets/raspberry-pi-3/default.nix
@@ -53,6 +53,11 @@ in {
     settings.PasswordAuthentication = true;
   };
 
+  services.deployment-start = {
+    enable = true;
+    output-path = "/output";
+  };
+
   services.audio-recorder = {
     enable = true;
     output-folder = "audio";

--- a/targets/raspberry-pi-3/default.nix
+++ b/targets/raspberry-pi-3/default.nix
@@ -55,7 +55,7 @@ in {
 
   services.audio-recorder = {
     enable = true;
-    output-folder = "/output/audio";
+    output-folder = "audio";
     sample-rate = 192000;
     sample-format = "S32_LE";
     channels = 4;
@@ -64,7 +64,7 @@ in {
 
   services.gps-recorder = {
     enable = true;
-    output-path = "/output/gps";
+    output-folder = "gps";
     interval-secs = 10;
   };
 

--- a/targets/raspberry-pi-4/default.nix
+++ b/targets/raspberry-pi-4/default.nix
@@ -57,13 +57,13 @@ in {
 
   services.gps-recorder = {
     enable = true;
-    output-path = "/output/gps";
+    output-folder = "gps";
     interval-secs = 10;
   };
 
   services.depth-recorder = {
     enable = true;
-    output-path = "/output/depth";
+    output-folder = "depth";
     interval-secs = 5;
   };
 

--- a/targets/raspberry-pi-4/default.nix
+++ b/targets/raspberry-pi-4/default.nix
@@ -38,7 +38,7 @@ in {
 
   services.deployment-start = {
     enable = true;
-    output-folder = "/output";
+    output-path = "/output";
   };
 
   services.audio-recorder = {

--- a/targets/raspberry-pi-4/default.nix
+++ b/targets/raspberry-pi-4/default.nix
@@ -36,9 +36,14 @@ in {
     settings.PasswordAuthentication = true;
   };
 
+  services.deployment-start = {
+    enable = true;
+    output-folder = "/output";
+  };
+
   services.audio-recorder = {
     enable = true;
-    output-folder = "/output/audio";
+    output-folder = "audio";
     sample-rate = 192000;
     sample-format = "S32_LE";
     channels = 4;
@@ -47,7 +52,7 @@ in {
 
   services.journalctl-log-export = {
     enable = true;
-    output-folder = "/output/logs";
+    output-folder = "logs";
   };
 
   services.gps-recorder = {

--- a/targets/raspberry-pi-4/default.nix
+++ b/targets/raspberry-pi-4/default.nix
@@ -62,7 +62,7 @@ in {
   };
 
   services.depth-recorder = {
-    enable = true;
+    enable = false;
     output-folder = "depth";
     interval-secs = 5;
   };


### PR DESCRIPTION
- Before, files were written to recording type specific subdirectories under /output. Now, a new timestamped directory will be created for each deployment (=boot) under which directories for audio, gps, depth, and logs will be created
- Create deployment-start service that runs before recording services start and which creates the deployment directory and exports it as an environment variable that can be read by other systemd services
- Update file & directory timestamp format to %Y-%m-%dT%H_%M_%S%z